### PR TITLE
Set up Cursor Cloud dev environment for the Go TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo (branch `v2`) is a Go [Bubble Tea](https://github.com/charmbracelet/bubbletea) TUI that orchestrates [Browsertrix Crawler](https://github.com/webrecorder/browsertrix-crawler) in Docker to produce Webrecorder/WACZ archives. See `README.md` for user-facing commands; the notes below are the non-obvious bits for developing/running it here.
+
+### Layout
+- `cmd/archive` — CLI entrypoint (subcommands: `quit`, `server start|stop`, `help`; no args launches the TUI).
+- `internal/tui` — Bubble Tea UI.
+- `internal/archive` — Docker orchestration (image build, crawl run, preview server) + the only unit tests (`normalize_test.go`).
+- `internal/config` — `.env` loading.
+- `resources/` — `Dockerfile.webrecorder`, `webrecorder.sh` (runs inside the container), `docker-compose.yml` (Apache preview server).
+
+### Build / test / run
+- Build: `go build -o archive ./cmd/archive`
+- Test: `go test ./...` — Vet: `go vet ./...`
+- Run: `./archive` (interactive TUI), `./archive quit`, `./archive server start` / `./archive server stop`.
+
+### Non-obvious caveats
+- Docker is required and the daemon is already running in this environment (storage driver `fuse-overlayfs`). No `sudo`/daemon start needed.
+- On the first archive run the TUI builds the Docker image `site-archiving-toolkit-webrecorder` from `resources/Dockerfile.webrecorder`. This pulls `webrecorder/browsertrix-crawler:latest` and `apt install`s packages, so it needs network egress; the first build takes longer, later runs are cached.
+- Crawling also needs egress to the target site and to `cdn.jsdelivr.net` (ReplayWeb.page assets are fetched inside the container).
+- The TUI uses the alt-screen and needs a real interactive TTY — you can't drive it through a plain piped shell. To demo/test it, run `./archive` in an actual terminal (e.g. via the Desktop) and press `ctrl+s` to start; the non-interactive subcommands (`quit`, `server ...`, `help`) work fine from a normal shell.
+- `main.findRoot()` locates the repo root by walking up looking for `resources/Dockerfile.webrecorder` (falling back to the executable's dir). Run `./archive` from inside the repo (or keep `resources/` next to the binary).
+- `.env` (created from `resources/env.example` on first run), `archive.ini` (regenerated each run), and everything under `crawls/` are gitignored build/runtime artifacts — do not commit them. Delete `.env` to reset config to defaults.
+- `./archive server start` binds host port 80.
+- Quick end-to-end sanity check: archive `https://example.com` — a small single page that crawls in a few seconds and produces a `.wacz` (and a `.zip`) under `crawls/<timestamp>-example.com/webrecorder/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the `v2` Go Bubble Tea TUI that orchestrates Browsertrix Crawler in Docker. No application code was changed — this only adds `AGENTS.md` with durable, non-obvious dev notes for future cloud agents.

## Environment verification

- Go 1.24.2 and Docker 29.6.2 (daemon running, `fuse-overlayfs`) are present.
- Build: `go build -o archive ./cmd/archive` ✓
- Vet: `go vet ./...` ✓
- Tests: `go test ./...` ✓ (`internal/archive` passes)
- Docker image build from `resources/Dockerfile.webrecorder` ✓
- End-to-end: archived `https://example.com` via the interactive TUI — produced a `.wacz` + `.zip` under `crawls/` ✓
- Preview server: `./archive server start` serves the crawl listing at `http://localhost` (HTTP 200) ✓

Update script (dependency refresh): `go mod download`.

## Demo

[archive_tui_demo.mp4](https://cursor.com/agents/bc-c81b7fa7-e1b0-4625-8266-0e9dfbf4b26a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farchive_tui_demo.mp4)

[Archive run finished](https://cursor.com/agents/bc-c81b7fa7-e1b0-4625-8266-0e9dfbf4b26a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftui_finished_screen.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c81b7fa7-e1b0-4625-8266-0e9dfbf4b26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c81b7fa7-e1b0-4625-8266-0e9dfbf4b26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

